### PR TITLE
Resolve the "_doing_it_wrong" warning, which has appeared in WordPres…

### DIFF
--- a/multi-device-switcher.php
+++ b/multi-device-switcher.php
@@ -144,7 +144,7 @@ class Multi_Device_Switcher {
 	 * @since 1.0.0
 	 */
 	public function __construct() {
-		add_action( 'plugins_loaded', array( $this, 'load_plugin_data' ) );
+		add_action( 'init', array( $this, 'load_plugin_data' ) );
 		add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
 		add_action( 'plugins_loaded', array( $this, 'init' ) );
 


### PR DESCRIPTION
WordPress 6.7 and later has begun displaying the following warning. I found that delaying the load from `plugins_loaded` timing resolves the issue.

```
Notice: Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the multi-device-switcher domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the init action or later. Please see Debugging in WordPress for more information. (This message was added in version 6.7.0.) in xxxxx/wp-includes/functions.php on line 6114
```

c.f.
  https://core.trac.wordpress.org/ticket/62462